### PR TITLE
[SYSREG2] Upgrade "revision.c" to Git from SVN

### DIFF
--- a/makefile
+++ b/makefile
@@ -31,8 +31,8 @@ revision.c:
 	echo ';' >> revision.c
 
 .PHONY: clean
+
 clean:
 	-@rm $(TARGET)
 	-@rm $(OBJS_C)
 	-@rm $(OBJS_CPP)
-					

--- a/makefile
+++ b/makefile
@@ -26,9 +26,9 @@ $(TARGET): $(OBJS_C) $(OBJS_CPP)
 	$(CC) $(INC) $(CFLAGS) -c $< -o $@
 
 revision.c:
-	echo 'const int SVNRev = ' > revision.c
-	LC_ALL=C LANG=C svn info | grep Revision | cut -f 2 -d " " >> revision.c
-	echo ';' >> revision.c
+	echo -n 'const char gGitCommit[] = "' > revision.c
+	echo -n $$(git describe --abbrev=7 --long --always) >> revision.c
+	echo '";' >> revision.c
 
 .PHONY: clean
 

--- a/sysreg.h
+++ b/sysreg.h
@@ -48,7 +48,7 @@ extern "C"
 {
 #endif
 
-extern const int SVNRev;
+extern const char gGitCommit[];
 
 typedef struct _stage
 {

--- a/virt.cpp
+++ b/virt.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 
     InitializeModuleList();
 
-    SysregPrintf("sysreg2 r%d starting\n", SVNRev);
+    SysregPrintf("sysreg2 %s starting\n", gGitCommit);
 
     if (!LoadSettings(argc > 1 ? argv[1] : "sysreg.xml"))
     {


### PR DESCRIPTION
Fixes
```bash
echo 'const int SVNRev = ' > revision.c
LC_ALL=C LANG=C svn info | grep Revision | cut -f 2 -d " " >> revision.c
svn: E155007: '/home/appveyor/sysreg2_workdir' is not a working copy
echo ';' >> revision.c
gcc -I/usr/include/libvirt/ -I/usr/include/libxml2/ -g -O0 -std=c99 -D_GNU_SOURCE -Wall -Wextra -c revision.c -o revision.o
revision.c:2:1: error: expected expression before ‘;’ token
;
^
makefile:26: recipe for target 'revision.o' failed
make: *** [revision.o] Error 1
```

--

Result example:
`sysreg2 65d7945 starting`

---

Obviously, creating at least 1 tag in Git would be interesting...