### PR TITLE
[SYSREG2] Limit the number of retries to 10

### DIFF
--- a/sysreg.xml
+++ b/sysreg.xml
@@ -18,7 +18,7 @@
 		<maxcachehits value="50" />
 
 		<!-- Maximum number of retries allowed before we cancel the entire testing process. -->
-		<maxretries value="35" />
+		<maxretries value="10" />
 
 		<!-- Maximum number of cont that sysreg will issue after a bt during the whole life of an instance -->
 		<maxconts value="5" />


### PR DESCRIPTION
Usually the first few retries already don't seem to yield a result,
but going up to 35 is just wasting time.